### PR TITLE
Fix: Consistently assert exception code

### DIFF
--- a/test/Unit/Exception/IndexOutOfBoundsTest.php
+++ b/test/Unit/Exception/IndexOutOfBoundsTest.php
@@ -48,5 +48,6 @@ final class IndexOutOfBoundsTest extends Framework\TestCase
         );
 
         $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
     }
 }

--- a/test/Unit/Exception/NoSignificantTokenFoundTest.php
+++ b/test/Unit/Exception/NoSignificantTokenFoundTest.php
@@ -49,8 +49,8 @@ final class NoSignificantTokenFoundTest extends Framework\TestCase
             $index
         );
 
-        $this->assertSame(0, $exception->getCode());
         $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
     }
 
     public function providerDirectionAndFormat(): \Generator


### PR DESCRIPTION
This PR

* [x] consistently asserts the exception code of exceptions created with named constructors