### PR TITLE
Fix: Do not export phpbench.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /.php_cs            export-ignore
 /.travis.yml        export-ignore
 /Makefile           export-ignore
+/phpbench.json      export-ignore


### PR DESCRIPTION
This PR

* [x] add `phpbench.json` to the list of files that should not be exported

Follows #6.