### PR TITLE
Fix: Use self instead of class name as return type

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -45,9 +45,9 @@ final class Sequence implements \Countable
      *
      * @param string $source
      *
-     * @return Sequence
+     * @return self
      */
-    public static function fromSource(string $source): Sequence
+    public static function fromSource(string $source): self
     {
         return new self(\token_get_all(
             $source,


### PR DESCRIPTION
This PR

* [x] uses `self` instead of `Sequence` as return type

Follows #2.