### PR TITLE
Fix: Do not use TOKEN_PARSE flag

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -49,10 +49,7 @@ final class Sequence implements \Countable
      */
     public static function fromSource(string $source): self
     {
-        return new self(\token_get_all(
-            $source,
-            TOKEN_PARSE
-        ));
+        return new self(\token_get_all($source));
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] stops using the `TOKEN_PARSE` flag

💁‍♂️ I can't see a reason to use it, and to be honest, I don't even know what it does.