### PR TITLE
Fix: Lazily create token value object when requesting it

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -30,13 +30,7 @@ final class Sequence implements \Countable
 
     private function __construct(array $tokens)
     {
-        $this->tokens = \array_map(function (int $index, $value) {
-            return Token::fromValue(
-                $index,
-                $value
-            );
-        }, \array_keys($tokens), \array_values($tokens));
-
+        $this->tokens = \array_values($tokens);
         $this->count = \count($tokens);
     }
 
@@ -67,6 +61,13 @@ final class Sequence implements \Countable
             throw Exception\IndexOutOfBounds::fromCountAndIndex(
                 $this->count,
                 $index
+            );
+        }
+
+        if (!$this->tokens[$index] instanceof Token) {
+            $this->tokens[$index] = Token::fromValue(
+                $index,
+                $this->tokens[$index]
             );
         }
 
@@ -152,7 +153,7 @@ final class Sequence implements \Countable
         }
 
         for ($current = $index + $direction; 0 <= $current && $current < $this->count; $current += $direction) {
-            $token = $this->tokens[$current];
+            $token = $this->at($current);
 
             if (!$token->isType(T_COMMENT, T_DOC_COMMENT, T_WHITESPACE)) {
                 return $token;


### PR DESCRIPTION
This PR

* [x] improves performance by lazily creating the `Token` value object when requesting it, rather than iterating over the entire sequence

### Before

```
+-------------+----------------------------+--------+--------+------+-----+------------+-------------+-------------+-------------+-------------+---------+--------+----------+
| benchmark   | subject                    | groups | params | revs | its | mem_peak   | best        | mean        | mode        | worst       | stdev   | rstdev | diff     |
+-------------+----------------------------+--------+--------+------+-----+------------+-------------+-------------+-------------+-------------+---------+--------+----------+
| ClassyBench | benchTokenGetAllFromSource |        | []     | 100  | 1   | 4,700,808b | 1,233.620μs | 1,233.620μs | 1,233.620μs | 1,233.620μs | 0.000μs | 0.00%  | 0.00%    |
| ClassyBench | benchSequenceFromSource    |        | []     | 100  | 1   | 7,321,488b | 6,743.240μs | 6,743.240μs | 6,743.240μs | 6,743.240μs | 0.000μs | 0.00%  | +446.62% |
+-------------+----------------------------+--------+--------+------+-----+------------+-------------+-------------+-------------+-------------+---------+--------+----------+
```

### After

```
+-------------+----------------------------+--------+--------+------+-----+------------+-------------+-------------+-------------+-------------+---------+--------+---------+
| benchmark   | subject                    | groups | params | revs | its | mem_peak   | best        | mean        | mode        | worst       | stdev   | rstdev | diff    |
+-------------+----------------------------+--------+--------+------+-----+------------+-------------+-------------+-------------+-------------+---------+--------+---------+
| ClassyBench | benchTokenGetAllFromSource |        | []     | 100  | 1   | 4,700,808b | 1,225.360μs | 1,225.360μs | 1,225.360μs | 1,225.360μs | 0.000μs | 0.00%  | 0.00%   |
| ClassyBench | benchSequenceFromSource    |        | []     | 100  | 1   | 5,171,760b | 1,524.940μs | 1,524.940μs | 1,524.940μs | 1,524.940μs | 0.000μs | 0.00%  | +24.45% |
+-------------+----------------------------+--------+--------+------+-----+------------+-------------+-------------+-------------+-------------+---------+--------+---------+
```