### PR TITLE
Fix: Use TOKEN_PARSE flag

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -43,7 +43,10 @@ final class Sequence implements \Countable
      */
     public static function fromSource(string $source): self
     {
-        return new self(\token_get_all($source));
+        return new self(\token_get_all(
+            $source,
+            TOKEN_PARSE
+        ));
     }
 
     /**

--- a/test/Bench/ClassyBench.php
+++ b/test/Bench/ClassyBench.php
@@ -23,7 +23,10 @@ final class ClassyBench
      */
     public function benchTokenGetAllFromSource()
     {
-        \token_get_all($this->source());
+        \token_get_all(
+            $this->source(),
+            TOKEN_PARSE
+        );
     }
 
     /**

--- a/test/Unit/SequenceTest.php
+++ b/test/Unit/SequenceTest.php
@@ -43,6 +43,35 @@ final class SequenceTest extends Framework\TestCase
         $this->assertInstanceOf(Sequence::class, $sequence);
     }
 
+    public function testFromSourceUsesTokenParse()
+    {
+        $source = <<<'PHP'
+<?php
+
+final class Example
+{
+    public function class(): string
+    {
+        return self::class;
+    }
+}
+PHP;
+
+        $sequence = Sequence::fromSource($source);
+
+        $classTokens = [];
+
+        for ($index = 0; $index < $sequence->count(); ++$index) {
+            $token = $sequence->at($index);
+
+            if ($token->isType(T_CLASS)) {
+                $classTokens[] = $token;
+            }
+        }
+
+        $this->assertCount(1, $classTokens);
+    }
+
     public function testCountReturnsNumberOfTokens()
     {
         $source = \file_get_contents(__FILE__);


### PR DESCRIPTION
This PR

* [x] asserts that `TOKEN_PARSE` is used
* [ ] uses the `TOKEN_PARSE` flag when parsing source code with `token_get_all()`

Reverts #9.

💁‍♂️ Updating `localheinz/token` in `localheinz/classy` reveals the advantage of using `TOKEN_PARSE`, as occurrences of reserved keywords will be parsed differently. 

```php
use Localheinz\Token\Sequence;

$source = <<<'PHP
final class Example 
{
    public function class() : string
    {
        return self::class;
    }
}
PHP;

$sequence = Sequence::fromSource($source);
```

### With `TOKEN_PARSE`

Sequence will contain 1 token of type `T_CLASS`.

### Without `TOKEN_PARSE`

Sequence will contain 3 tokens of type `T_CLASS`.



