### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ jobs:
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
-        - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
         - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
         - if [[ "$WITH_LOCKED" == "true" ]]; then composer install; fi
         - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require-dev": {
     "infection/infection": "~0.11.2",
     "localheinz/composer-normalize": "^1.1.0",
-    "localheinz/php-cs-fixer-config": "~1.17.0",
+    "localheinz/php-cs-fixer-config": "~1.19.0",
     "localheinz/test-util": "~0.7.0",
     "phpbench/phpbench": "~0.14.0",
     "phpunit/phpunit": "^7.4.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41d3208dfbb661940dfcd04f6caaef4f",
+    "content-hash": "7705753e4a6ea9da0734c2df6da5f757",
     "packages": [],
     "packages-dev": [
         {
@@ -574,16 +574,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.1",
+            "version": "v2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161"
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/54814c62d5beef3ba55297b9b3186ed8b8a1b161",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
                 "shasum": ""
             },
             "require": {
@@ -592,7 +592,7 @@
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
                 "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
@@ -610,7 +610,7 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.2",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
@@ -630,6 +630,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.14-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -661,7 +666,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-10-21T00:32:10+00:00"
+            "time": "2019-01-04T18:29:47+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1131,20 +1136,20 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.17.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115"
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6237bcf8636243bc2d1a995f67c49ac58cb76188",
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.13.1",
+                "friendsofphp/php-cs-fixer": "^2.14.0",
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
@@ -1168,7 +1173,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2018-11-27T07:03:30+00:00"
+            "time": "2019-01-04T23:09:58+00:00"
         },
         {
             "name": "localheinz/test-util",
@@ -3533,20 +3538,21 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862"
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8b93ce06506d58485893e2da366767dcc5390862",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/921f49c3158a276d27c0d770a5a347a3b718b328",
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
@@ -3565,7 +3571,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3592,7 +3598,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T10:26:29+00:00"
+            "time": "2018-12-01T08:52:38+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -3695,16 +3701,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "31e5523373cb06163079ef46d0a2d507d70fe064"
+                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/31e5523373cb06163079ef46d0a2d507d70fe064",
-                "reference": "31e5523373cb06163079ef46d0a2d507d70fe064",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
+                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
                 "shasum": ""
             },
             "require": {
@@ -3713,7 +3719,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3745,7 +3751,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4029,25 +4035,26 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "87a801786adb053576dc025892e01fedde9b4fc7"
+                "reference": "ec076716412274e51f8a7ea675d9515e5c311123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/87a801786adb053576dc025892e01fedde9b4fc7",
-                "reference": "87a801786adb053576dc025892e01fedde9b4fc7",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/ec076716412274e51f8a7ea675d9515e5c311123",
+                "reference": "ec076716412274e51f8a7ea675d9515e5c311123",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4074,7 +4081,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Exception/IndexOutOfBounds.php
+++ b/src/Exception/IndexOutOfBounds.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/NoSignificantTokenFound.php
+++ b/src/Exception/NoSignificantTokenFound.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Token.php
+++ b/src/Token.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Bench/ClassyBench.php
+++ b/test/Bench/ClassyBench.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -21,7 +21,7 @@ final class ClassyBench
     /**
      * @Revs(100)
      */
-    public function benchTokenGetAllFromSource()
+    public function benchTokenGetAllFromSource(): void
     {
         \token_get_all(
             $this->source(),
@@ -32,7 +32,7 @@ final class ClassyBench
     /**
      * @Revs(100)
      */
-    public function benchSequenceFromSource()
+    public function benchSequenceFromSource(): void
     {
         Sequence::fromSource($this->source());
     }

--- a/test/Unit/Exception/IndexOutOfBoundsTest.php
+++ b/test/Unit/Exception/IndexOutOfBoundsTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,12 +24,12 @@ final class IndexOutOfBoundsTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsOutOfBoundsException()
+    public function testExtendsOutOfBoundsException(): void
     {
         $this->assertClassExtends(\OutOfBoundsException::class, IndexOutOfBounds::class);
     }
 
-    public function testFromCountAndIndexReturnsException()
+    public function testFromCountAndIndexReturnsException(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Exception/NoSignificantTokenFoundTest.php
+++ b/test/Unit/Exception/NoSignificantTokenFoundTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,7 +25,7 @@ final class NoSignificantTokenFoundTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsRuntimeException()
+    public function testExtendsRuntimeException(): void
     {
         $this->assertClassExtends(\RuntimeException::class, NoSignificantTokenFound::class);
     }
@@ -36,7 +36,7 @@ final class NoSignificantTokenFoundTest extends Framework\TestCase
      * @param int    $direction
      * @param string $format
      */
-    public function testInReturnsException(int $direction, string $format)
+    public function testInReturnsException(int $direction, string $format): void
     {
         $index = $this->faker()->randomNumber();
 

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -23,12 +23,12 @@ final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testProductionClassesAreAbstractOrFinal()
+    public function testProductionClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
     }
 
-    public function testProductionClassesHaveTests()
+    public function testProductionClassesHaveTests(): void
     {
         $this->assertClassesHaveTests(
             __DIR__ . '/../../src',
@@ -37,7 +37,7 @@ final class ProjectCodeTest extends Framework\TestCase
         );
     }
 
-    public function testTestClassesAreAbstractOrFinal()
+    public function testTestClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
     }

--- a/test/Unit/SequenceTest.php
+++ b/test/Unit/SequenceTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -26,18 +26,18 @@ final class SequenceTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsCountableInterface()
+    public function testImplementsCountableInterface(): void
     {
         $this->assertClassImplementsInterface(\Countable::class, Sequence::class);
     }
 
-    public function testConstants()
+    public function testConstants(): void
     {
         self::assertSame(-1, Sequence::DIRECTION_BACKWARD);
         self::assertSame(1, Sequence::DIRECTION_FORWARD);
     }
 
-    public function testFromSourceReturnsSequenceOfTokens()
+    public function testFromSourceReturnsSequenceOfTokens(): void
     {
         $source = \file_get_contents(__FILE__);
 
@@ -46,7 +46,7 @@ final class SequenceTest extends Framework\TestCase
         self::assertInstanceOf(Sequence::class, $sequence);
     }
 
-    public function testFromSourceUsesTokenParse()
+    public function testFromSourceUsesTokenParse(): void
     {
         $source = <<<'PHP'
 <?php
@@ -75,7 +75,7 @@ PHP;
         self::assertCount(1, $classTokens);
     }
 
-    public function testCountReturnsNumberOfTokens()
+    public function testCountReturnsNumberOfTokens(): void
     {
         $source = \file_get_contents(__FILE__);
         $tokens = \token_get_all(
@@ -95,7 +95,7 @@ PHP;
      * @param string $source
      * @param int    $index
      */
-    public function testAtThrowsIndexOutOfBoundsIfIndexIsOutOfBounds(string $source, int $index)
+    public function testAtThrowsIndexOutOfBoundsIfIndexIsOutOfBounds(string $source, int $index): void
     {
         $sequence = Sequence::fromSource($source);
 
@@ -127,7 +127,7 @@ PHP;
         }
     }
 
-    public function testAtReturnsTokenAtIndex()
+    public function testAtReturnsTokenAtIndex(): void
     {
         $source = \file_get_contents(__FILE__);
         $tokens = \token_get_all(
@@ -156,7 +156,7 @@ PHP;
      * @param string $source
      * @param int    $index
      */
-    public function testSignificantBeforeThrowsIndexOutOfBoundsIfIndexIsOutOfBounds(string $source, int $index)
+    public function testSignificantBeforeThrowsIndexOutOfBoundsIfIndexIsOutOfBounds(string $source, int $index): void
     {
         $sequence = Sequence::fromSource($source);
 
@@ -165,7 +165,7 @@ PHP;
         $sequence->significantBefore($index);
     }
 
-    public function testSignificantBeforeThrowsNoSignificantTokenFoundIfNoSignificantTokenFound()
+    public function testSignificantBeforeThrowsNoSignificantTokenFoundIfNoSignificantTokenFound(): void
     {
         $source = <<<'PHP'
 <?php
@@ -197,7 +197,7 @@ PHP;
      * @param int    $index
      * @param int    $indexSignificantBefore
      */
-    public function testSignificantBeforeReturnsSignificantTokenBeforeIndex(string $source, int $index, int $indexSignificantBefore)
+    public function testSignificantBeforeReturnsSignificantTokenBeforeIndex(string $source, int $index, int $indexSignificantBefore): void
     {
         $sequence = Sequence::fromSource($source);
 
@@ -269,7 +269,7 @@ PHP;
      * @param string $source
      * @param int    $index
      */
-    public function testSignificantAfterThrowsIndexOutOfBoundsIfIndexIsOutOfBounds(string $source, int $index)
+    public function testSignificantAfterThrowsIndexOutOfBoundsIfIndexIsOutOfBounds(string $source, int $index): void
     {
         $sequence = Sequence::fromSource($source);
 
@@ -284,7 +284,7 @@ PHP;
      * @param string $source
      * @param int    $index
      */
-    public function testSignificantAfterThrowsNoSignificantTokenFoundIfNoSignificantTokenFound(string $source, int $index)
+    public function testSignificantAfterThrowsNoSignificantTokenFoundIfNoSignificantTokenFound(string $source, int $index): void
     {
         $sequence = Sequence::fromSource($source);
 
@@ -336,7 +336,7 @@ PHP;
      * @param int    $index
      * @param int    $indexSignificantAfter
      */
-    public function testSignificantAfterReturnsSignificantTokenAfterIndex(string $source, int $index, int $indexSignificantAfter)
+    public function testSignificantAfterReturnsSignificantTokenAfterIndex(string $source, int $index, int $indexSignificantAfter): void
     {
         $sequence = Sequence::fromSource($source);
 

--- a/test/Unit/TokenTest.php
+++ b/test/Unit/TokenTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,7 +24,7 @@ final class TokenTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testFromTypeAndContentReturnsToken()
+    public function testFromTypeAndContentReturnsToken(): void
     {
         $faker = $this->faker();
 
@@ -45,7 +45,7 @@ final class TokenTest extends Framework\TestCase
         self::assertSame($content, $token->content());
     }
 
-    public function testFromStringReturnsToken()
+    public function testFromStringReturnsToken(): void
     {
         $faker = $this->faker();
 
@@ -71,7 +71,7 @@ final class TokenTest extends Framework\TestCase
      * @param array|string $value
      * @param Token        $expected
      */
-    public function testFromValueReturnsToken(int $index, $value, Token $expected)
+    public function testFromValueReturnsToken(int $index, $value, Token $expected): void
     {
         $token = Token::fromValue(
             $index,
@@ -119,7 +119,7 @@ final class TokenTest extends Framework\TestCase
         }
     }
 
-    public function testIsTypeReturnsFalseIfTypeIsDifferent()
+    public function testIsTypeReturnsFalseIfTypeIsDifferent(): void
     {
         $faker = $this->faker();
 
@@ -134,7 +134,7 @@ final class TokenTest extends Framework\TestCase
         self::assertFalse($token->isType($type));
     }
 
-    public function testIsTypeReturnsFalseIfAllTypesAreDifferent()
+    public function testIsTypeReturnsFalseIfAllTypesAreDifferent(): void
     {
         $faker = $this->faker();
 
@@ -153,7 +153,7 @@ final class TokenTest extends Framework\TestCase
         self::assertFalse($token->isType(...$types));
     }
 
-    public function testIsTypeReturnsTrueIfTypeIsSame()
+    public function testIsTypeReturnsTrueIfTypeIsSame(): void
     {
         $faker = $this->faker();
 
@@ -168,7 +168,7 @@ final class TokenTest extends Framework\TestCase
         self::assertTrue($token->isType($type));
     }
 
-    public function testIsTypeReturnsTrueIfOneTypeIsSame()
+    public function testIsTypeReturnsTrueIfOneTypeIsSame(): void
     {
         $faker = $this->faker();
 
@@ -188,7 +188,7 @@ final class TokenTest extends Framework\TestCase
         self::assertTrue($token->isType(...$types));
     }
 
-    public function testIsContentReturnsFalseIfContentIsDifferent()
+    public function testIsContentReturnsFalseIfContentIsDifferent(): void
     {
         $faker = $this->faker();
 
@@ -203,7 +203,7 @@ final class TokenTest extends Framework\TestCase
         self::assertFalse($token->isContent($content));
     }
 
-    public function testIsContentReturnsFalseIfAllContentsAreDifferent()
+    public function testIsContentReturnsFalseIfAllContentsAreDifferent(): void
     {
         $faker = $this->faker();
 
@@ -222,7 +222,7 @@ final class TokenTest extends Framework\TestCase
         self::assertFalse($token->isContent(...$contents));
     }
 
-    public function testIsContentReturnsTrueIfContentIsSame()
+    public function testIsContentReturnsTrueIfContentIsSame(): void
     {
         $faker = $this->faker();
 
@@ -237,7 +237,7 @@ final class TokenTest extends Framework\TestCase
         self::assertTrue($token->isContent($content));
     }
 
-    public function testIsContentReturnsTrueIfOneContentIsSame()
+    public function testIsContentReturnsTrueIfOneContentIsSame(): void
     {
         $faker = $this->faker();
 


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config` 
* [x] runs `make cs`
* [x] does not remove `localheinz/php-cs-fixer-config` on PHP 7.3

💁‍♂️ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.17.0...1.19.0.